### PR TITLE
Update Catppuccin themes

### DIFF
--- a/src/addon/themes/(dark) Catppuccin Frappe.json
+++ b/src/addon/themes/(dark) Catppuccin Frappe.json
@@ -1,0 +1,305 @@
+{
+    "colors": {
+        "ACCENT_CARD": [
+            "Card mode",
+            "#8caaee",
+            "#8caaee",
+            "--accent-card"
+        ],
+        "ACCENT_DANGER": [
+            "Danger",
+            "#e78284",
+            "#e78284",
+            "--accent-danger"
+        ],
+        "ACCENT_NOTE": [
+            "Note mode",
+            "#a6d189",
+            "#a6d189",
+            "--accent-note"
+        ],
+        "BORDER": [
+            "Border",
+            "#51576d",
+            "#51576d",
+            "--border"
+        ],
+        "BORDER_FOCUS": [
+            "Border (focused input)",
+            "#f2d5cf",
+            "#f2d5cf",
+            "--border-focus"
+        ],
+        "BORDER_STRONG": [
+            "Border (strong)",
+            "#626880",
+            "#626880",
+            "--border-strong"
+        ],
+        "BORDER_SUBTLE": [
+            "Border (subtle)",
+            "#414559",
+            "#414559",
+            "--border-subtle"
+        ],
+        "BUTTON_BG": [
+            "Button background",
+            "#414559",
+            "#414559",
+            "--button-bg"
+        ],
+        "BUTTON_DISABLED": [
+            "Button background (disabled)",
+            "#414559",
+            "#414559",
+            "--button-disabled"
+        ],
+        "BUTTON_HOVER": [
+            "Button background (hover)",
+            "#51576d",
+            "#51576d",
+            [
+                "--button-gradient-start",
+                "--button-gradient-end"
+            ]
+        ],
+        "BUTTON_HOVER_BORDER": [
+            "Button border (hover)",
+            "#626880",
+            "#626880",
+            "--button-hover-border"
+        ],
+        "BUTTON_PRIMARY_BG": [
+            "Button Primary Bg",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-bg"
+        ],
+        "BUTTON_PRIMARY_DISABLED": [
+            "Button Primary Disabled",
+            "#4484ed",
+            "#4484ed",
+            "--button-primary-disabled"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_END": [
+            "Button Primary Gradient End",
+            "#2544a8",
+            "#2544a8",
+            "--button-primary-gradient-end"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_START": [
+            "Button Primary Gradient Start",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-gradient-start"
+        ],
+        "CANVAS": [
+            "Background",
+            "#303446",
+            "#303446",
+            "--canvas"
+        ],
+        "CANVAS_CODE": [
+            "Code editor background",
+            "#292c3c",
+            "#292c3c",
+            "--canvas-code"
+        ],
+        "CANVAS_ELEVATED": [
+            "Review",
+            "#292c3c",
+            "#292c3c",
+            "--canvas-elevated"
+        ],
+        "CANVAS_INSET": [
+            "Background (inset)",
+            "#232634",
+            "#232634",
+            "--canvas-inset"
+        ],
+        "CANVAS_OVERLAY": [
+            "Background (menu & tooltip)",
+            "#292c3c",
+            "#292c3c",
+            "--canvas-overlay"
+        ],
+        "FG": [
+            "Text",
+            "#c6d0f5",
+            "#c6d0f5",
+            "--fg"
+        ],
+        "FG_DISABLED": [
+            "Text (disabled)",
+            "#a6adc6",
+            "#a6adc6",
+            "--fg-disabled"
+        ],
+        "FG_FAINT": [
+            "Text (faint)",
+            "#949cbb",
+            "#949cbb",
+            "--fg-faint"
+        ],
+        "FG_LINK": [
+            "Text (link)",
+            "#f2d5cf",
+            "#f2d5cf",
+            "--fg-link"
+        ],
+        "FG_SUBTLE": [
+            "Text (subtle)",
+            "#b5bfe2",
+            "#b5bfe2",
+            "--fg-subtle"
+        ],
+        "FLAG_1": [
+            "Flag 1",
+            "#e78284",
+            "#e78284",
+            "--flag-1"
+        ],
+        "FLAG_2": [
+            "Flag 2",
+            "#ef9f76",
+            "#ef9f76",
+            "--flag-2"
+        ],
+        "FLAG_3": [
+            "Flag 3",
+            "#a6d189",
+            "#a6d189",
+            "--flag-3"
+        ],
+        "FLAG_4": [
+            "Flag 4",
+            "#8caaee",
+            "#8caaee",
+            "--flag-4"
+        ],
+        "FLAG_5": [
+            "Flag 5",
+            "#ca9ee6",
+            "#ca9ee6",
+            "--flag-5"
+        ],
+        "FLAG_6": [
+            "Flag 6",
+            "#99d1db",
+            "#99d1db",
+            "--flag-6"
+        ],
+        "FLAG_7": [
+            "Flag 7",
+            "#babbf1",
+            "#babbf1",
+            "--flag-7"
+        ],
+        "HIGHLIGHT_BG": [
+            "Highlight background",
+            "#414559",
+            "#414559",
+            "--highlight-bg"
+        ],
+        "HIGHLIGHT_FG": [
+            "Highlight text",
+            "#f2d5cf",
+            "#f2d5cf",
+            "--highlight-fg"
+        ],
+        "SCROLLBAR_BG": [
+            "Scrollbar background",
+            "#303446",
+            "#303446",
+            "--scrollbar-bg"
+        ],
+        "SCROLLBAR_BG_ACTIVE": [
+            "Scrollbar background (active)",
+            "#414559",
+            "#414559",
+            "--scrollbar-bg-active"
+        ],
+        "SCROLLBAR_BG_HOVER": [
+            "Scrollbar background (hover)",
+            "#303446",
+            "#303446",
+            "--scrollbar-bg-hover"
+        ],
+        "SELECTED_BG": [
+            "Selected Bg",
+            "#414559",
+            "#414559",
+            "--selected-bg"
+        ],
+        "SELECTED_FG": [
+            "Selected Fg",
+            "#f2d5cf",
+            "#f2d5cf",
+            "--selected-fg"
+        ],
+        "SHADOW": [
+            "Shadow",
+            "#303446",
+            "#303446",
+            "--shadow"
+        ],
+        "SHADOW_FOCUS": [
+            "Shadow (focused input)",
+            "#ef9f76",
+            "#ef9f76",
+            "--shadow-focus"
+        ],
+        "SHADOW_INSET": [
+            "Shadow (inset)",
+            "#232634",
+            "#232634",
+            "--shadow-inset"
+        ],
+        "SHADOW_SUBTLE": [
+            "Shadow (subtle)",
+            "#292c3c",
+            "#292c3c",
+            "--shadow-subtle"
+        ],
+        "STATE_BURIED": [
+            "Buried",
+            "#838ba7",
+            "#838ba7",
+            "--state-buried"
+        ],
+        "STATE_LEARN": [
+            "Learn",
+            "#e78284",
+            "#e78284",
+            "--state-learn"
+        ],
+        "STATE_MARKED": [
+            "Marked",
+            "#e5c890",
+            "#e5c890",
+            "--state-marked"
+        ],
+        "STATE_NEW": [
+            "New",
+            "#8caaee",
+            "#8caaee",
+            "--state-new"
+        ],
+        "STATE_REVIEW": [
+            "Review",
+            "#a6d189",
+            "#a6d189",
+            "--state-review"
+        ],
+        "STATE_SUSPENDED": [
+            "Suspended",
+            "#a5adce",
+            "#a5adce",
+            "--state-suspended"
+        ]
+    },
+    "version": {
+        "major": 2,
+        "minor": 4
+    }
+}

--- a/src/addon/themes/(dark) Catppuccin Macchiato.json
+++ b/src/addon/themes/(dark) Catppuccin Macchiato.json
@@ -2,62 +2,62 @@
     "colors": {
         "ACCENT_CARD": [
             "Card mode",
-            "#60a5fa",
-            "#93c5fd",
+            "#8aadf4",
+            "#8aadf4",
             "--accent-card"
         ],
         "ACCENT_DANGER": [
             "Danger",
-            "#ef4444",
-            "#f87171",
+            "#ed8796",
+            "#ed8796",
             "--accent-danger"
         ],
         "ACCENT_NOTE": [
             "Note mode",
-            "#22c55e",
-            "#4ade80",
+            "#a6da95",
+            "#a6da95",
             "--accent-note"
         ],
         "BORDER": [
             "Border",
-            "#575268",
-            "#575268",
+            "#494d64",
+            "#494d64",
             "--border"
         ],
         "BORDER_FOCUS": [
             "Border (focused input)",
-            "#3b82f6",
-            "#3b82f6",
+            "#f4dbd6",
+            "#f4dbd6",
             "--border-focus"
         ],
         "BORDER_STRONG": [
             "Border (strong)",
-            "#858585",
-            "#020202",
+            "#5b6078",
+            "#5b6078",
             "--border-strong"
         ],
         "BORDER_SUBTLE": [
             "Border (subtle)",
-            "#1E1E2E",
-            "#1E1E2E",
+            "#363a4f",
+            "#363a4f",
             "--border-subtle"
         ],
         "BUTTON_BG": [
             "Button background",
-            "#1E1E2E",
-            "#1E1E2E",
+            "#363a4f",
+            "#363a4f",
             "--button-bg"
         ],
         "BUTTON_DISABLED": [
             "Button background (disabled)",
-            "#d6d6d680",
-            "#45454580",
+            "#363a4f",
+            "#363a4f",
             "--button-disabled"
         ],
         "BUTTON_HOVER": [
             "Button background (hover)",
-            "#1A1826",
-            "#1A1826",
+            "#494d64",
+            "#494d64",
             [
                 "--button-gradient-start",
                 "--button-gradient-end"
@@ -65,241 +65,241 @@
         ],
         "BUTTON_HOVER_BORDER": [
             "Button border (hover)",
-            "#999999",
-            "#141414",
+            "#5b6078",
+            "#5b6078",
             "--button-hover-border"
         ],
         "BUTTON_PRIMARY_BG": [
             "Button Primary Bg",
-            "#60a5fa",
+            "#2f67e1",
             "#2f67e1",
             "--button-primary-bg"
         ],
         "BUTTON_PRIMARY_DISABLED": [
             "Button Primary Disabled",
-            "#93c5fd",
+            "#4484ed",
             "#4484ed",
             "--button-primary-disabled"
         ],
         "BUTTON_PRIMARY_GRADIENT_END": [
             "Button Primary Gradient End",
-            "#2563eb",
+            "#2544a8",
             "#2544a8",
             "--button-primary-gradient-end"
         ],
         "BUTTON_PRIMARY_GRADIENT_START": [
             "Button Primary Gradient Start",
-            "#60a5fa",
+            "#2f67e1",
             "#2f67e1",
             "--button-primary-gradient-start"
         ],
         "CANVAS": [
             "Background",
-            "#1E1E2E",
-            "#1E1E2E",
+            "#24273a",
+            "#24273a",
             "--canvas"
         ],
         "CANVAS_CODE": [
             "Code editor background",
-            "#eeeeee",
-            "#252525",
+            "#1e2030",
+            "#1e2030",
             "--canvas-code"
         ],
         "CANVAS_ELEVATED": [
-            "Background (elevated)",
-            "#1A1826",
-            "#1A1826",
+            "Review",
+            "#1e2030",
+            "#1e2030",
             "--canvas-elevated"
         ],
         "CANVAS_INSET": [
             "Background (inset)",
-            "#1A1826",
-            "#1A1826",
+            "#181926",
+            "#181926",
             "--canvas-inset"
         ],
         "CANVAS_OVERLAY": [
             "Background (menu & tooltip)",
-            "#1E1E2E",
-            "#1E1E2E",
+            "#1e2030",
+            "#1e2030",
             "--canvas-overlay"
         ],
         "FG": [
             "Text",
-            "#D9E0EE",
-            "#D9E0EE",
+            "#cad3f5",
+            "#cad3f5",
             "--fg"
         ],
         "FG_DISABLED": [
             "Text (disabled)",
-            "#F8BD96",
-            "#F8BD96",
+            "#a6adc6",
+            "#a6adc6",
             "--fg-disabled"
         ],
         "FG_FAINT": [
             "Text (faint)",
-            "#6E6C7E",
-            "#6E6C7E",
+            "#939ab7",
+            "#939ab7",
             "--fg-faint"
         ],
         "FG_LINK": [
             "Text (link)",
-            "#F8BD96",
-            "#F8BD96",
+            "#f4dbd6",
+            "#f4dbd6",
             "--fg-link"
         ],
         "FG_SUBTLE": [
             "Text (subtle)",
-            "#C3BAC6",
-            "#C3BAC6",
+            "#b8c0e0",
+            "#b8c0e0",
             "--fg-subtle"
         ],
         "FLAG_1": [
             "Flag 1",
-            "#F28FAD",
-            "#F28FAD",
+            "#ed8796",
+            "#ed8796",
             "--flag-1"
         ],
         "FLAG_2": [
             "Flag 2",
-            "#F8BD96",
-            "#F8BD96",
+            "#f5a97f",
+            "#f5a97f",
             "--flag-2"
         ],
         "FLAG_3": [
             "Flag 3",
-            "#ABE9B3",
-            "#ABE9B3",
+            "#a6da95",
+            "#a6da95",
             "--flag-3"
         ],
         "FLAG_4": [
             "Flag 4",
-            "#96CDFB",
-            "#96CDFB",
+            "#8aadf4",
+            "#8aadf4",
             "--flag-4"
         ],
         "FLAG_5": [
             "Flag 5",
-            "#DDB6F2",
-            "#DDB6F2",
+            "#c6a0f6",
+            "#c6a0f6",
             "--flag-5"
         ],
         "FLAG_6": [
             "Flag 6",
-            "#89DCEB",
-            "#89DCEB",
+            "#91d7e3",
+            "#91d7e3",
             "--flag-6"
         ],
         "FLAG_7": [
             "Flag 7",
-            "#C9CBFF",
-            "#C9CBFF",
+            "#b7bdf8",
+            "#b7bdf8",
             "--flag-7"
         ],
         "HIGHLIGHT_BG": [
             "Highlight background",
-            "#C9CBFF",
-            "#C9CBFF",
+            "#363a4f",
+            "#363a4f",
             "--highlight-bg"
         ],
         "HIGHLIGHT_FG": [
             "Highlight text",
-            "#F5E0DC",
-            "#F5E0DC",
+            "#f4dbd6",
+            "#f4dbd6",
             "--highlight-fg"
         ],
         "SCROLLBAR_BG": [
             "Scrollbar background",
-            "#d6d6d6",
-            "#363636",
+            "#24273a",
+            "#24273a",
             "--scrollbar-bg"
         ],
         "SCROLLBAR_BG_ACTIVE": [
             "Scrollbar background (active)",
-            "#afafaf",
-            "#636363",
+            "#363a4f",
+            "#363a4f",
             "--scrollbar-bg-active"
         ],
         "SCROLLBAR_BG_HOVER": [
             "Scrollbar background (hover)",
-            "#c4c4c4",
-            "#454545",
+            "#24273a",
+            "#24273a",
             "--scrollbar-bg-hover"
         ],
         "SELECTED_BG": [
             "Selected Bg",
-            "#d6d6d680",
-            "#93c5fd80",
+            "#363a4f",
+            "#363a4f",
             "--selected-bg"
         ],
         "SELECTED_FG": [
             "Selected Fg",
-            "black",
-            "white",
+            "#f4dbd6",
+            "#f4dbd6",
             "--selected-fg"
         ],
         "SHADOW": [
             "Shadow",
-            "#c4c4c4",
-            "#202020",
+            "#24273a",
+            "#24273a",
             "--shadow"
         ],
         "SHADOW_FOCUS": [
             "Shadow (focused input)",
-            "#6366f1",
-            "#6366f1",
+            "#f5a97f",
+            "#f5a97f",
             "--shadow-focus"
         ],
         "SHADOW_INSET": [
             "Shadow (inset)",
-            "#454545",
-            "#202020",
+            "#181926",
+            "#181926",
             "--shadow-inset"
         ],
         "SHADOW_SUBTLE": [
             "Shadow (subtle)",
-            "#737373",
-            "#363636",
+            "#1e2030",
+            "#1e2030",
             "--shadow-subtle"
         ],
         "STATE_BURIED": [
             "Buried",
-            "#f59e0b",
-            "#92400e",
+            "#8087a2",
+            "#8087a2",
             "--state-buried"
         ],
         "STATE_LEARN": [
             "Learn",
-            "#F28FAD",
-            "#F28FAD",
+            "#ed8796",
+            "#ed8796",
             "--state-learn"
         ],
         "STATE_MARKED": [
             "Marked",
-            "#FAE3B0",
-            "#FAE3B0",
+            "#eed49f",
+            "#eed49f",
             "--state-marked"
         ],
         "STATE_NEW": [
             "New",
-            "#96CDFB",
-            "#96CDFB",
+            "#8aadf4",
+            "#8aadf4",
             "--state-new"
         ],
         "STATE_REVIEW": [
             "Review",
-            "#ABE9B3",
-            "#ABE9B3",
+            "#a6da95",
+            "#a6da95",
             "--state-review"
         ],
         "STATE_SUSPENDED": [
             "Suspended",
-            "#D9E0EE",
-            "#D9E0EE",
+            "#a5adcb",
+            "#a5adcb",
             "--state-suspended"
         ]
     },
     "version": {
         "major": 2,
-        "minor": 1
+        "minor": 4
     }
 }

--- a/src/addon/themes/(dark) Catppuccin Mocha.json
+++ b/src/addon/themes/(dark) Catppuccin Mocha.json
@@ -1,0 +1,305 @@
+{
+    "colors": {
+        "ACCENT_CARD": [
+            "Card mode",
+            "#89b4fa",
+            "#89b4fa",
+            "--accent-card"
+        ],
+        "ACCENT_DANGER": [
+            "Danger",
+            "#f38ba8",
+            "#f38ba8",
+            "--accent-danger"
+        ],
+        "ACCENT_NOTE": [
+            "Note mode",
+            "#a6e3a1",
+            "#a6e3a1",
+            "--accent-note"
+        ],
+        "BORDER": [
+            "Border",
+            "#45475a",
+            "#45475a",
+            "--border"
+        ],
+        "BORDER_FOCUS": [
+            "Border (focused input)",
+            "#f5e0dc",
+            "#f5e0dc",
+            "--border-focus"
+        ],
+        "BORDER_STRONG": [
+            "Border (strong)",
+            "#585b70",
+            "#585b70",
+            "--border-strong"
+        ],
+        "BORDER_SUBTLE": [
+            "Border (subtle)",
+            "#313244",
+            "#313244",
+            "--border-subtle"
+        ],
+        "BUTTON_BG": [
+            "Button background",
+            "#313244",
+            "#313244",
+            "--button-bg"
+        ],
+        "BUTTON_DISABLED": [
+            "Button background (disabled)",
+            "#313244",
+            "#313244",
+            "--button-disabled"
+        ],
+        "BUTTON_HOVER": [
+            "Button background (hover)",
+            "#45475a",
+            "#45475a",
+            [
+                "--button-gradient-start",
+                "--button-gradient-end"
+            ]
+        ],
+        "BUTTON_HOVER_BORDER": [
+            "Button border (hover)",
+            "#585b70",
+            "#585b70",
+            "--button-hover-border"
+        ],
+        "BUTTON_PRIMARY_BG": [
+            "Button Primary Bg",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-bg"
+        ],
+        "BUTTON_PRIMARY_DISABLED": [
+            "Button Primary Disabled",
+            "#4484ed",
+            "#4484ed",
+            "--button-primary-disabled"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_END": [
+            "Button Primary Gradient End",
+            "#2544a8",
+            "#2544a8",
+            "--button-primary-gradient-end"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_START": [
+            "Button Primary Gradient Start",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-gradient-start"
+        ],
+        "CANVAS": [
+            "Background",
+            "#1e1e2e",
+            "#1e1e2e",
+            "--canvas"
+        ],
+        "CANVAS_CODE": [
+            "Code editor background",
+            "#181825",
+            "#181825",
+            "--canvas-code"
+        ],
+        "CANVAS_ELEVATED": [
+            "Review",
+            "#181825",
+            "#181825",
+            "--canvas-elevated"
+        ],
+        "CANVAS_INSET": [
+            "Background (inset)",
+            "#11111b",
+            "#11111b",
+            "--canvas-inset"
+        ],
+        "CANVAS_OVERLAY": [
+            "Background (menu & tooltip)",
+            "#181825",
+            "#181825",
+            "--canvas-overlay"
+        ],
+        "FG": [
+            "Text",
+            "#cdd6f4",
+            "#cdd6f4",
+            "--fg"
+        ],
+        "FG_DISABLED": [
+            "Text (disabled)",
+            "#a6adc6",
+            "#a6adc6",
+            "--fg-disabled"
+        ],
+        "FG_FAINT": [
+            "Text (faint)",
+            "#9399b2",
+            "#9399b2",
+            "--fg-faint"
+        ],
+        "FG_LINK": [
+            "Text (link)",
+            "#f5e0dc",
+            "#f5e0dc",
+            "--fg-link"
+        ],
+        "FG_SUBTLE": [
+            "Text (subtle)",
+            "#bac2de",
+            "#bac2de",
+            "--fg-subtle"
+        ],
+        "FLAG_1": [
+            "Flag 1",
+            "#f38ba8",
+            "#f38ba8",
+            "--flag-1"
+        ],
+        "FLAG_2": [
+            "Flag 2",
+            "#fab387",
+            "#fab387",
+            "--flag-2"
+        ],
+        "FLAG_3": [
+            "Flag 3",
+            "#a6e3a1",
+            "#a6e3a1",
+            "--flag-3"
+        ],
+        "FLAG_4": [
+            "Flag 4",
+            "#89b4fa",
+            "#89b4fa",
+            "--flag-4"
+        ],
+        "FLAG_5": [
+            "Flag 5",
+            "#cba6f7",
+            "#cba6f7",
+            "--flag-5"
+        ],
+        "FLAG_6": [
+            "Flag 6",
+            "#89dceb",
+            "#89dceb",
+            "--flag-6"
+        ],
+        "FLAG_7": [
+            "Flag 7",
+            "#c9cbff",
+            "#c9cbff",
+            "--flag-7"
+        ],
+        "HIGHLIGHT_BG": [
+            "Highlight background",
+            "#313244",
+            "#313244",
+            "--highlight-bg"
+        ],
+        "HIGHLIGHT_FG": [
+            "Highlight text",
+            "#f5e0dc",
+            "#f5e0dc",
+            "--highlight-fg"
+        ],
+        "SCROLLBAR_BG": [
+            "Scrollbar background",
+            "#1e1e2e",
+            "#1e1e2e",
+            "--scrollbar-bg"
+        ],
+        "SCROLLBAR_BG_ACTIVE": [
+            "Scrollbar background (active)",
+            "#313244",
+            "#313244",
+            "--scrollbar-bg-active"
+        ],
+        "SCROLLBAR_BG_HOVER": [
+            "Scrollbar background (hover)",
+            "#1e1e2e",
+            "#1e1e2e",
+            "--scrollbar-bg-hover"
+        ],
+        "SELECTED_BG": [
+            "Selected Bg",
+            "#313244",
+            "#313244",
+            "--selected-bg"
+        ],
+        "SELECTED_FG": [
+            "Selected Fg",
+            "#f5e0dc",
+            "#f5e0dc",
+            "--selected-fg"
+        ],
+        "SHADOW": [
+            "Shadow",
+            "#1e1e2e",
+            "#1e1e2e",
+            "--shadow"
+        ],
+        "SHADOW_FOCUS": [
+            "Shadow (focused input)",
+            "#fab387",
+            "#fab387",
+            "--shadow-focus"
+        ],
+        "SHADOW_INSET": [
+            "Shadow (inset)",
+            "#11111b",
+            "#11111b",
+            "--shadow-inset"
+        ],
+        "SHADOW_SUBTLE": [
+            "Shadow (subtle)",
+            "#181825",
+            "#181825",
+            "--shadow-subtle"
+        ],
+        "STATE_BURIED": [
+            "Buried",
+            "#7f849c",
+            "#7f849c",
+            "--state-buried"
+        ],
+        "STATE_LEARN": [
+            "Learn",
+            "#f38ba8",
+            "#f38ba8",
+            "--state-learn"
+        ],
+        "STATE_MARKED": [
+            "Marked",
+            "#FAE3B0",
+            "#FAE3B0",
+            "--state-marked"
+        ],
+        "STATE_NEW": [
+            "New",
+            "#96cdfb",
+            "#96cdfb",
+            "--state-new"
+        ],
+        "STATE_REVIEW": [
+            "Review",
+            "#a6e3a1",
+            "#a6e3a1",
+            "--state-review"
+        ],
+        "STATE_SUSPENDED": [
+            "Suspended",
+            "#a6adc8",
+            "#a6adc8",
+            "--state-suspended"
+        ]
+    },
+    "version": {
+        "major": 2,
+        "minor": 4
+    }
+}

--- a/src/addon/themes/(light) Catppuccin Latte.json
+++ b/src/addon/themes/(light) Catppuccin Latte.json
@@ -1,0 +1,305 @@
+{
+    "colors": {
+        "ACCENT_CARD": [
+            "Card mode",
+            "#1e66f5",
+            "#1e66f5",
+            "--accent-card"
+        ],
+        "ACCENT_DANGER": [
+            "Danger",
+            "#d20f39",
+            "#d20f39",
+            "--accent-danger"
+        ],
+        "ACCENT_NOTE": [
+            "Note mode",
+            "#40a02b",
+            "#40a02b",
+            "--accent-note"
+        ],
+        "BORDER": [
+            "Border",
+            "#bcc0cc",
+            "#bcc0cc",
+            "--border"
+        ],
+        "BORDER_FOCUS": [
+            "Border (focused input)",
+            "#dc8a78",
+            "#dc8a78",
+            "--border-focus"
+        ],
+        "BORDER_STRONG": [
+            "Border (strong)",
+            "#acb0be",
+            "#acb0be",
+            "--border-strong"
+        ],
+        "BORDER_SUBTLE": [
+            "Border (subtle)",
+            "#ccd0da",
+            "#ccd0da",
+            "--border-subtle"
+        ],
+        "BUTTON_BG": [
+            "Button background",
+            "#ccd0da",
+            "#ccd0da",
+            "--button-bg"
+        ],
+        "BUTTON_DISABLED": [
+            "Button background (disabled)",
+            "#ccd0da",
+            "#ccd0da",
+            "--button-disabled"
+        ],
+        "BUTTON_HOVER": [
+            "Button background (hover)",
+            "#bcc0cc",
+            "#bcc0cc",
+            [
+                "--button-gradient-start",
+                "--button-gradient-end"
+            ]
+        ],
+        "BUTTON_HOVER_BORDER": [
+            "Button border (hover)",
+            "#acb0be",
+            "#acb0be",
+            "--button-hover-border"
+        ],
+        "BUTTON_PRIMARY_BG": [
+            "Button Primary Bg",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-bg"
+        ],
+        "BUTTON_PRIMARY_DISABLED": [
+            "Button Primary Disabled",
+            "#4484ed",
+            "#4484ed",
+            "--button-primary-disabled"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_END": [
+            "Button Primary Gradient End",
+            "#2544a8",
+            "#2544a8",
+            "--button-primary-gradient-end"
+        ],
+        "BUTTON_PRIMARY_GRADIENT_START": [
+            "Button Primary Gradient Start",
+            "#2f67e1",
+            "#2f67e1",
+            "--button-primary-gradient-start"
+        ],
+        "CANVAS": [
+            "Background",
+            "#eff1f5",
+            "#eff1f5",
+            "--canvas"
+        ],
+        "CANVAS_CODE": [
+            "Code editor background",
+            "#e6e9ef",
+            "#e6e9ef",
+            "--canvas-code"
+        ],
+        "CANVAS_ELEVATED": [
+            "Review",
+            "#e6e9ef",
+            "#e6e9ef",
+            "--canvas-elevated"
+        ],
+        "CANVAS_INSET": [
+            "Background (inset)",
+            "#dce0e8",
+            "#dce0e8",
+            "--canvas-inset"
+        ],
+        "CANVAS_OVERLAY": [
+            "Background (menu & tooltip)",
+            "#e6e9ef",
+            "#e6e9ef",
+            "--canvas-overlay"
+        ],
+        "FG": [
+            "Text",
+            "#4c4f69",
+            "#4c4f69",
+            "--fg"
+        ],
+        "FG_DISABLED": [
+            "Text (disabled)",
+            "#a6adc6",
+            "#a6adc6",
+            "--fg-disabled"
+        ],
+        "FG_FAINT": [
+            "Text (faint)",
+            "#7c7f93",
+            "#7c7f93",
+            "--fg-faint"
+        ],
+        "FG_LINK": [
+            "Text (link)",
+            "#dc8a78",
+            "#dc8a78",
+            "--fg-link"
+        ],
+        "FG_SUBTLE": [
+            "Text (subtle)",
+            "#5c5f77",
+            "#5c5f77",
+            "--fg-subtle"
+        ],
+        "FLAG_1": [
+            "Flag 1",
+            "#d20f39",
+            "#d20f39",
+            "--flag-1"
+        ],
+        "FLAG_2": [
+            "Flag 2",
+            "#fe640b",
+            "#fe640b",
+            "--flag-2"
+        ],
+        "FLAG_3": [
+            "Flag 3",
+            "#40a02b",
+            "#40a02b",
+            "--flag-3"
+        ],
+        "FLAG_4": [
+            "Flag 4",
+            "#1e66f5",
+            "#1e66f5",
+            "--flag-4"
+        ],
+        "FLAG_5": [
+            "Flag 5",
+            "#8839ef",
+            "#8839ef",
+            "--flag-5"
+        ],
+        "FLAG_6": [
+            "Flag 6",
+            "#04a5e5",
+            "#04a5e5",
+            "--flag-6"
+        ],
+        "FLAG_7": [
+            "Flag 7",
+            "#7287fd",
+            "#7287fd",
+            "--flag-7"
+        ],
+        "HIGHLIGHT_BG": [
+            "Highlight background",
+            "#ccd0da",
+            "#ccd0da",
+            "--highlight-bg"
+        ],
+        "HIGHLIGHT_FG": [
+            "Highlight text",
+            "#dc8a78",
+            "#dc8a78",
+            "--highlight-fg"
+        ],
+        "SCROLLBAR_BG": [
+            "Scrollbar background",
+            "#eff1f5",
+            "#eff1f5",
+            "--scrollbar-bg"
+        ],
+        "SCROLLBAR_BG_ACTIVE": [
+            "Scrollbar background (active)",
+            "#ccd0da",
+            "#ccd0da",
+            "--scrollbar-bg-active"
+        ],
+        "SCROLLBAR_BG_HOVER": [
+            "Scrollbar background (hover)",
+            "#eff1f5",
+            "#eff1f5",
+            "--scrollbar-bg-hover"
+        ],
+        "SELECTED_BG": [
+            "Selected Bg",
+            "#ccd0da",
+            "#ccd0da",
+            "--selected-bg"
+        ],
+        "SELECTED_FG": [
+            "Selected Fg",
+            "#dc8a78",
+            "#dc8a78",
+            "--selected-fg"
+        ],
+        "SHADOW": [
+            "Shadow",
+            "#eff1f5",
+            "#eff1f5",
+            "--shadow"
+        ],
+        "SHADOW_FOCUS": [
+            "Shadow (focused input)",
+            "#fe640b",
+            "#fe640b",
+            "--shadow-focus"
+        ],
+        "SHADOW_INSET": [
+            "Shadow (inset)",
+            "#dce0e8",
+            "#dce0e8",
+            "--shadow-inset"
+        ],
+        "SHADOW_SUBTLE": [
+            "Shadow (subtle)",
+            "#e6e9ef",
+            "#e6e9ef",
+            "--shadow-subtle"
+        ],
+        "STATE_BURIED": [
+            "Buried",
+            "#8c8fa1",
+            "#8c8fa1",
+            "--state-buried"
+        ],
+        "STATE_LEARN": [
+            "Learn",
+            "#d20f39",
+            "#d20f39",
+            "--state-learn"
+        ],
+        "STATE_MARKED": [
+            "Marked",
+            "#df8e1d",
+            "#df8e1d",
+            "--state-marked"
+        ],
+        "STATE_NEW": [
+            "New",
+            "#1e66f5",
+            "#1e66f5",
+            "--state-new"
+        ],
+        "STATE_REVIEW": [
+            "Review",
+            "#40a02b",
+            "#40a02b",
+            "--state-review"
+        ],
+        "STATE_SUSPENDED": [
+            "Suspended",
+            "#6c6f85",
+            "#6c6f85",
+            "--state-suspended"
+        ]
+    },
+    "version": {
+        "major": 2,
+        "minor": 4
+    }
+}


### PR DESCRIPTION
Catppuccin recently updated their [anki port](https://github.com/catppuccin/anki) to match the current colorscheme. This PR updates the Catppuccin theme file to use the new versions.